### PR TITLE
Rename project to MTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Many-Time Pad Interactive
+# MTP
 
 Keys in One-time pad encryption (OTP) should only be used once, when they get reused we can do a Many-time pad attack.
 
@@ -6,7 +6,7 @@ MTP Interactive uses automated cryptanalysis to present a partial decryption whi
 
 ## Install
 
-Currently no availably on PyPI, the project must be cloned and installed
+The project must be cloned and installed
 
 ```
 pip install .
@@ -15,7 +15,7 @@ pip install .
 ## Usage
 
 ```
-mtp-interactive examples/sample.ciphertexts
+mtp examples/sample.ciphertexts
 ```
 
 TODO: asciinema demo

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-urwid
+urwid==2.0.1

--- a/setup.py
+++ b/setup.py
@@ -2,18 +2,20 @@
 
 from setuptools import setup, find_packages
 
-
 setup(
-    name='mtp-interactive',
-    version='1.0.0',
-    description='Interactive Many Time Pad',
+    name='mtp',
+    version='0.0.2',
+    description='Many-Time Pad Interactive',
     author='Cameron Lonsdale',
     author_email='cameron.lonsdale@gmail.com',
-    url='https://github.com/CameronLonsdale/Many-Time-Pad-Interactive',
+    url='https://github.com/CameronLonsdale/MTP',
     license='MIT',
     packages=find_packages(),
     scripts=['cli.py'],
+    install_requires=[
+        "urwid==2.0.1"
+    ],
     entry_points={
-    	'console_scripts': ['mtp-interactive=cli:main']
+    	'console_scripts': ['mtp=cli:main']
     }
 )


### PR DESCRIPTION
Because MTP is a shorter name, and it was available on PyPi